### PR TITLE
Add env to jnlp container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,9 @@ spec:
       volumeMounts:
       - mountPath: /home/jenkins/.ssh
         name: volume-known-hosts
+      env:
+      - name: "HOME"
+        value: "/home/jenkins/agent"
     - name: hugo
       image: eclipsecbi/hugo:0.42.1
       command:


### PR DESCRIPTION
Ass described in comment 8 in the eclipse bug
https://bugs.eclipse.org/bugs/show_bug.cgi?id=551507
Recent changes in the Jenkins Kubernetes Plugin require to define
environment variables in the jnlp container

Additional difference to before not displayed in the PR:
- credentials have been supplied in the Jenkins

Signed-off-by: Stephanie Neubauer <Stephanie.Neubauer@bosch-si.com>